### PR TITLE
Add type hints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
             python: "3.14"
             tox: "3.14"
             coverage: true
-          # - name: "pyright"
-          #   python: "3.14"
-          #   tox: "pyright"
+          - name: "pyright"
+            python: "3.14"
+            tox: "pyright"
           - name: "ruff check"
             python: "3.14"
             tox: "ruff-check"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
           - name: "ruff format"
             python: "3.14"
             tox: "ruff-format"
+          - name: "ty"
+            python: "3.14"
+            tox: "ty"
 
     name: ${{ matrix.name }}
     runs-on: ubuntu-24.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,11 +79,6 @@ target-version = "py313"
 select = ["ALL"]
 ignore = [
     # Add rules you want to ignore here
-    "ANN001", # missing-type-function-argument  # TODO
-    "ANN201", # missing-return-type-undocumented-public-function  # TODO
-    "ANN202", # missing-return-type-private-function  # TODO
-    "ANN204", # missing-return-type-special-method  # TODO
-    "ANN205", # missing-return-type-static-method  # TODO
     "D",      # pydocstyle
     "D203",   # one-blank-line-before-class
     "D213",   # multi-line-summary-second-line
@@ -98,6 +93,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [
+    "ANN",     # flake8-annotations
     "ARG",     # flake8-unused-arguments
     "D",       # pydocstyle
     "PLR2004", # magic-value-comparison  # TODO

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
 ]
 ruff = ["ruff"]
 tests = ["pytest", "pytest-cov"]
-typing = ["pyright"]
+typing = ["pyright", "ty"]
 
 
 [tool.coverage.paths]
@@ -120,6 +120,7 @@ env_list = [
     "pyright",
     "ruff-check",
     "ruff-format",
+    "ty",
 ]
 
 [tool.tox.env_run_base]
@@ -148,3 +149,7 @@ commands = [["ruff", "check", "{posargs:.}"]]
 skip_install = true
 dependency_groups = ["ruff"]
 commands = [["ruff", "format", "--check", "--diff", "{posargs:.}"]]
+
+[tool.tox.env.ty]
+dependency_groups = ["typing"]
+commands = [["ty", "check", "{posargs:src}"]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "beaker",
-    "mopidy >= 3.0",
+    "mopidy >= 4.0.0a11",
     "pykka >= 4.1",
     "python-dateutil",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "beaker",
-    "mopidy >= 4.0.0a11",
+    "mopidy >= 4.0.0a4",
     "pykka >= 4.1",
     "python-dateutil",
 ]

--- a/src/mopidy_orfradio/__init__.py
+++ b/src/mopidy_orfradio/__init__.py
@@ -25,7 +25,7 @@ class Extension(ext.Extension):
         schema["livestream_bitrate"] = config.Integer(choices=[128, 192])
         return schema
 
-    def setup(self, registry) -> None:
+    def setup(self, registry: ext.Registry) -> None:
         from mopidy_orfradio.backend import ORFBackend  # noqa: PLC0415
 
         registry.add("backend", ORFBackend)

--- a/src/mopidy_orfradio/backend.py
+++ b/src/mopidy_orfradio/backend.py
@@ -17,7 +17,11 @@ class ORFBackend(pykka.ThreadingActor, backend.Backend):
     uri_schemes: ClassVar[list[UriScheme]] = [UriScheme("orfradio")]
     config: config_lib.ConfigDict
 
-    def __init__(self, config: config_lib.Config, audio: AudioProxy):
+    def __init__(
+        self,
+        config: config_lib.Config,
+        audio: AudioProxy,
+    ) -> None:
         super().__init__()
 
         self.config = cast("config_lib.ConfigDict", config)

--- a/src/mopidy_orfradio/backend.py
+++ b/src/mopidy_orfradio/backend.py
@@ -1,5 +1,5 @@
 import logging
-from typing import ClassVar, cast
+from typing import ClassVar
 
 import pykka
 from mopidy import backend
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class ORFBackend(pykka.ThreadingActor, backend.Backend):
     uri_schemes: ClassVar[list[UriScheme]] = [UriScheme("orfradio")]
-    config: config_lib.ConfigDict
+    config: config_lib.Config
 
     def __init__(
         self,
@@ -24,7 +24,7 @@ class ORFBackend(pykka.ThreadingActor, backend.Backend):
     ) -> None:
         super().__init__()
 
-        self.config = cast("config_lib.ConfigDict", config)
+        self.config = config
 
         self.library = ORFLibraryProvider(backend=self)
         self.playback = ORFPlaybackProvider(audio=audio, backend=self)

--- a/src/mopidy_orfradio/backend.py
+++ b/src/mopidy_orfradio/backend.py
@@ -1,7 +1,11 @@
 import logging
+from typing import ClassVar, cast
 
 import pykka
 from mopidy import backend
+from mopidy import config as config_lib
+from mopidy.audio import AudioProxy
+from mopidy.types import UriScheme
 
 from mopidy_orfradio.library import ORFLibraryProvider
 from mopidy_orfradio.playback import ORFPlaybackProvider
@@ -10,11 +14,13 @@ logger = logging.getLogger(__name__)
 
 
 class ORFBackend(pykka.ThreadingActor, backend.Backend):
-    def __init__(self, config, audio):
+    uri_schemes: ClassVar[list[UriScheme]] = [UriScheme("orfradio")]
+    config: config_lib.ConfigDict
+
+    def __init__(self, config: config_lib.Config, audio: AudioProxy):
         super().__init__()
 
-        self.config = config
+        self.config = cast("config_lib.ConfigDict", config)
 
         self.library = ORFLibraryProvider(backend=self)
         self.playback = ORFPlaybackProvider(audio=audio, backend=self)
-        self.uri_schemes = ["orfradio"]

--- a/src/mopidy_orfradio/client.py
+++ b/src/mopidy_orfradio/client.py
@@ -1,15 +1,19 @@
+from __future__ import annotations
+
 import datetime as dt
 import json
 import logging
 import re
-import urllib
-from typing import ClassVar
+import urllib.request
+from typing import TYPE_CHECKING, ClassVar
 
 import dateutil.parser
 from beaker.cache import CacheManager
 from beaker.util import parse_cache_config_options
+from mopidy.types import Uri
 
-from mopidy_orfradio import TZ
+if TYPE_CHECKING:
+    from mopidy_orfradio.backend import ORFBackend
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +24,7 @@ class HttpClient:
     cache = CacheManager(**parse_cache_config_options(cache_opts))
 
     @cache.cache("get", expire=300)
-    def get(self, url):
+    def get(self, url: str) -> str | None:
         logger.debug(f"Fetching data from {url!r}")
         if not url.startswith("http"):
             msg = f"Invalid URL: {url!r}"
@@ -32,8 +36,9 @@ class HttpClient:
             return content.decode(encoding)
         except Exception as exc:  # noqa: BLE001
             logger.error(f"Error fetching data from {url!r}: {exc}")  # noqa: TRY400
+            return None
 
-    def refresh(self):
+    def refresh(self) -> None:
         self.cache.invalidate(self.get, "get")
 
 
@@ -48,8 +53,12 @@ class ORFClient:
         192: "q2a",
     }
 
-    def __init__(self, http_client=HttpClient(), backend=None):  # noqa: B008
-        self.http_client = http_client
+    def __init__(
+        self,
+        http_client: HttpClient | None = None,
+        backend: ORFBackend | None = None,
+    ) -> None:
+        self.http_client = http_client or HttpClient()
         if backend:
             self.media_types = backend.config["orfradio"]["archive_types"]
             selected_bitrate = backend.config["orfradio"]["livestream_bitrate"]
@@ -58,8 +67,16 @@ class ORFClient:
             self.media_types = ["M", "B", "N"]
             self.live_bitrate = "q2a"
 
-    def get_day(self, station, day_id):
-        day_rec = self._get_day_json(station, day_id)
+    def get_day(
+        self,
+        *,
+        station: str,
+        day: dt.date,
+    ):
+        day_rec = self._get_day_json(
+            station=station,
+            day=day,
+        )
         if not day_rec:
             return []
 
@@ -73,14 +90,18 @@ class ORFClient:
             < now(broadcast_rec["endOffset"])
         ]
 
-    def get_show(self, station, day_id, show_id):
-        show_rec = self._get_record_json(station, show_id, day_id)
+    def get_show(self, *, station: str, day: dt.date, show_id: str):
+        show_rec = self._get_record_json(
+            station=station,
+            day=day,
+            show_id=show_id,
+        )
         if not show_rec:
             return []
         # Sometimes the first item isn't at the beginning of the show, making
         # part of it inaccessible. So we add a fake "zeroth" item when that
         # happens:
-        show_date = _get_day_label(day_id)
+        show_date = f"{day:%a %Y-%m-%d}"
         first_item = next(iter(show_rec["items"]), None)
         if first_item and show_rec["start"] < first_item["start"]:
             show_rec["items"].insert(
@@ -127,67 +148,104 @@ class ORFClient:
 
         return items
 
-    def get_live_url(self, slug):
-        return ORFClient.live_uri % (slug, self.live_bitrate)
+    def get_live_url(self, *, station: str) -> Uri:
+        return Uri(ORFClient.live_uri % (station, self.live_bitrate))
 
-    def get_item(self, station, day_id, show_id, item_id):
-        show = self.get_show(station, day_id, show_id)
+    def get_item(
+        self,
+        *,
+        station: str,
+        day: dt.date,
+        show_id: str,
+        item_id: str,
+    ):
+        show = self.get_show(
+            station=station,
+            day=day,
+            show_id=show_id,
+        )
         return next(
             item for item in show if item["id"].split("-")[0] == item_id.split("-")[0]
         )
 
-    def get_item_url(self, station, loopstream_slug, day_id, show_id, item_id):
-        json = self._get_record_json(station, show_id, day_id)
+    def get_item_url(
+        self,
+        *,
+        station: str,
+        day: dt.date,
+        show_id: str,
+        item_id: str,
+        loopstream_slug: str | None,
+    ) -> Uri | None:
+        if loopstream_slug is None:
+            return None
+
+        json = self._get_record_json(
+            station=station,
+            day=day,
+            show_id=show_id,
+        )
         if not json:
             return None
 
         streams = json["streams"]
         if len(streams) == 0:
-            return ""
+            return None
 
-        item_start, item_end, *_ = item_id.split("-", 1) + 1 * [None]
+        item_start, _, item_end = item_id.partition("-")
         stream = next(
             stream for stream in reversed(streams) if stream["start"] <= int(item_start)
         )
         stream_id = stream["loopStreamId"]
         offsetstart = int(item_start) - stream["start"]
         offsetende = int(item_end) - stream["start"] if item_end else ""
-        return ORFClient.show_uri % (
-            loopstream_slug,
-            stream_id,
-            offsetstart,
-            offsetende,
+        return Uri(
+            ORFClient.show_uri
+            % (
+                loopstream_slug,
+                stream_id,
+                offsetstart,
+                offsetende,
+            )
         )
 
     def refresh(self):
         self.http_client.refresh()
 
-    def _get_json(self, uri):
+    def _get_json(self, uri: str) -> dict | None:
+        content = self.http_client.get(uri)
+        if content is None:
+            return None
         try:
-            content = self.http_client.get(uri)
             return json.loads(content)
         except Exception as exc:  # noqa: BLE001
             logger.error(f"Error decoding content received from {uri!r}: {exc}")  # noqa: TRY400
+            return None
 
-    def _get_archive_json(self, station):
+    def _get_archive_json(self, *, station: str) -> dict | None:
         return self._get_json(ORFClient.archive_uri % station)
 
-    def _get_day_json(self, station, day_id):
-        json = self._get_archive_json(station)
-        return next((rec for rec in json if _get_day_id(rec) == day_id), None)
+    def _get_day_json(
+        self,
+        *,
+        station: str,
+        day: dt.date,
+    ) -> dict | None:
+        json = self._get_archive_json(station=station)
+        if json is None:
+            return None
+        return next((rec for rec in json if str(rec["day"]) == f"{day:%Y%m%d}"), None)
 
-    def _get_record_json(self, station, program_key, day):
-        return self._get_json(ORFClient.record_uri % (station, program_key, day))
-
-
-def _get_day_id(day_rec):
-    return str(day_rec["day"])
-
-
-def _get_day_label(day_id):
-    # The day id is a string in the form "YYYYMMDD".
-    date = dt.datetime.strptime(day_id, "%Y%m%d").replace(tzinfo=TZ)
-    return date.strftime("%a %Y-%m-%d")
+    def _get_record_json(
+        self,
+        *,
+        station: str,
+        day: dt.date,
+        show_id: str,
+    ) -> dict | None:
+        return self._get_json(
+            ORFClient.record_uri % (station, show_id, f"{day:%Y%m%d}")
+        )
 
 
 def _to_show(rec):

--- a/src/mopidy_orfradio/client.py
+++ b/src/mopidy_orfradio/client.py
@@ -5,7 +5,7 @@ import json
 import logging
 import re
 import urllib.request
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import dateutil.parser
 from beaker.cache import CacheManager
@@ -72,7 +72,7 @@ class ORFClient:
         *,
         station: str,
         day: dt.date,
-    ):
+    ) -> list[dict[str, Any]]:
         day_rec = self._get_day_json(
             station=station,
             day=day,
@@ -80,17 +80,25 @@ class ORFClient:
         if not day_rec:
             return []
 
-        def now(offset):
+        def now(offset: float) -> dt.datetime:
             return dt.datetime.now(dt.timezone(dt.timedelta(milliseconds=offset)))
 
         return [
             _to_show(broadcast_rec)
             for broadcast_rec in day_rec["broadcasts"]
-            if dateutil.parser.parse(broadcast_rec["startISO"])
-            < now(broadcast_rec["endOffset"])
+            if (
+                dateutil.parser.parse(broadcast_rec["startISO"])
+                < now(broadcast_rec["endOffset"])
+            )
         ]
 
-    def get_show(self, *, station: str, day: dt.date, show_id: str):
+    def get_show(
+        self,
+        *,
+        station: str,
+        day: dt.date,
+        show_id: str,
+    ) -> list[dict[str, Any]]:
         show_rec = self._get_record_json(
             station=station,
             day=day,
@@ -158,7 +166,7 @@ class ORFClient:
         day: dt.date,
         show_id: str,
         item_id: str,
-    ):
+    ) -> dict[str, Any]:
         show = self.get_show(
             station=station,
             day=day,
@@ -209,10 +217,10 @@ class ORFClient:
             )
         )
 
-    def refresh(self):
+    def refresh(self) -> None:
         self.http_client.refresh()
 
-    def _get_json(self, uri: str) -> dict | None:
+    def _get_json(self, uri: str) -> dict[str, Any] | None:
         content = self.http_client.get(uri)
         if content is None:
             return None
@@ -230,7 +238,7 @@ class ORFClient:
         *,
         station: str,
         day: dt.date,
-    ) -> dict | None:
+    ) -> dict[str, Any] | None:
         json = self._get_archive_json(station=station)
         if json is None:
             return None
@@ -242,13 +250,13 @@ class ORFClient:
         station: str,
         day: dt.date,
         show_id: str,
-    ) -> dict | None:
+    ) -> dict[str, Any] | None:
         return self._get_json(
             ORFClient.record_uri % (station, show_id, f"{day:%Y%m%d}")
         )
 
 
-def _to_show(rec):
+def _to_show(rec: dict[str, Any]) -> dict[str, Any]:
     time = dateutil.parser.parse(rec["scheduledISO"])
 
     # Note: items with times < 06:00 are from the next day and should be last
@@ -259,7 +267,7 @@ def _to_show(rec):
     }
 
 
-def _generic_title(track):
+def _generic_title(track: dict[str, Any]) -> str:
     types = {
         "M": "Musik ",
         "B": "Beitrag ",
@@ -272,7 +280,7 @@ def _generic_title(track):
     return types.get(track["type"], "") + "ohne Namen"
 
 
-def _generate_id(show_rec, i):
+def _generate_id(show_rec: dict[str, Any], i: int) -> str:
     start = show_rec["items"][i]["start"]
     if i + 1 < len(show_rec["items"]):
         end = show_rec["items"][i + 1]["start"]
@@ -280,7 +288,7 @@ def _generate_id(show_rec, i):
     return f"{start}"
 
 
-def _calculate_length(show_rec, i):
+def _calculate_length(show_rec: dict[str, Any], i: int) -> int:
     start = show_rec["items"][i]["start"]
     end = (
         show_rec["items"][i + 1]["start"]
@@ -290,7 +298,7 @@ def _calculate_length(show_rec, i):
     return end - start
 
 
-def _mojibake(s):
+def _mojibake(s: str) -> str:
     """
     The API sometimes returns titles with characters in the C1 control block.
     """

--- a/src/mopidy_orfradio/client.py
+++ b/src/mopidy_orfradio/client.py
@@ -60,8 +60,8 @@ class ORFClient:
     ) -> None:
         self.http_client = http_client or HttpClient()
         if backend:
-            self.media_types = backend.config["orfradio"]["archive_types"]
-            selected_bitrate = backend.config["orfradio"]["livestream_bitrate"]
+            self.media_types = backend.config["orfradio"]["archive_types"]  # type: ignore -- Fixed in mopidy >= 4.0.0a14
+            selected_bitrate = backend.config["orfradio"]["livestream_bitrate"]  # type: ignore -- Fixed in mopidy >= 4.0.0a14
             self.live_bitrate = self.bitrates[selected_bitrate]
         else:
             self.media_types = ["M", "B", "N"]

--- a/src/mopidy_orfradio/library.py
+++ b/src/mopidy_orfradio/library.py
@@ -186,5 +186,5 @@ class ORFLibraryProvider(backend.LibraryProvider):
         ]
 
     @override
-    def refresh(self, uri: Uri | None = None):
+    def refresh(self, uri: Uri | None = None) -> None:
         self.client.refresh()

--- a/src/mopidy_orfradio/library.py
+++ b/src/mopidy_orfradio/library.py
@@ -1,194 +1,183 @@
 from __future__ import annotations
 
-import datetime
+import datetime as dt
 import logging
 import re
-import urllib
-from enum import IntEnum
-from typing import ClassVar, override
+from typing import TYPE_CHECKING, Any, override
 
 from mopidy import backend
 from mopidy.models import Album, Artist, Ref, Track
 
 from mopidy_orfradio import TZ
 from mopidy_orfradio.client import ORFClient
+from mopidy_orfradio.stations import STATION_BY_SLUG, STATIONS
+from mopidy_orfradio.types import (
+    InvalidORFUriError,
+    ORFArchiveDayUri,
+    ORFArchiveItemUri,
+    ORFArchiveShowUri,
+    ORFLiveUri,
+    ORFRootUri,
+    ORFStationUri,
+    ORFUri,
+)
+
+if TYPE_CHECKING:
+    from mopidy.types import Uri
+
+    from mopidy_orfradio.backend import ORFBackend
 
 logger = logging.getLogger(__name__)
 
 
-class ORFUris:
-    ROOT = "orfradio"
-
-    # Mapping from audioapi_slug to (name, loopstream_slug)
-    stations: ClassVar[dict[str, tuple[str, str | None]]] = {
-        "oe1": ("Ö1", "oe1"),
-        "oe3": ("Ö3", "oe3"),
-        "fm4": ("FM4", "fm4"),
-        "campus": ("Ö1 Campus", None),
-        "bgl": ("Radio Burgenland", "oe2b"),
-        "ktn": ("Radio Kärnten", "oe2k"),
-        "noe": ("Radio Niederösterreich", "oe2n"),
-        "ooe": ("Radio Oberösterreich", "oe2o"),
-        "sbg": ("Radio Salzburg", "oe2s"),
-        "stm": ("Radio Steiermark", "oe2st"),
-        "tir": ("Radio Tirol", "oe2t"),
-        "vbg": ("Radio Vorarlberg", "oe2v"),
-        "wie": ("Radio Wien", "oe2w"),
-        "slo": ("ORF Slovenski spored", None),
-    }
-
-
 class ORFLibraryProvider(backend.LibraryProvider):
-    root_directory = Ref.directory(uri=f"{ORFUris.ROOT}:", name="ORF Radio")
+    backend: ORFBackend
 
-    def __init__(self, backend, client=None):
+    root_directory = Ref.directory(
+        uri=ORFRootUri().uri,
+        name="ORF Radio",
+    )
+
+    def __init__(
+        self,
+        backend: ORFBackend,
+        client: ORFClient | None = None,
+    ) -> None:
         super().__init__(backend)
         self.client = client or ORFClient(backend=self.backend)
         self.root = [
-            Ref.directory(uri=f"{ORFUris.ROOT}:{slug}", name=name)
-            for slug, (name, _) in ORFUris.stations.items()
-            if slug in self.backend.config["orfradio"]["stations"]
+            Ref.directory(
+                uri=station.as_station_uri().uri,
+                name=station.name,
+            )
+            for station in STATIONS
+            if station.slug in self.backend.config["orfradio"]["stations"]
         ]
 
     @override
-    def browse(self, uri):
+    def browse(self, uri: Uri) -> list[Ref]:
         try:
-            library_uri = ORFLibraryUri.parse(uri)
+            orf_uri = ORFUri.parse(uri)
         except InvalidORFUriError as e:
             logger.error(e)  # noqa: TRY400
             return []
 
-        match library_uri.uri_type:
-            case ORFUriType.ROOT:
+        match orf_uri:
+            case ORFRootUri():
                 return self.root
-            case ORFUriType.STATION:
-                return self._browse_station(library_uri.station)
-            case ORFUriType.ARCHIVE_DAY:
-                return self._browse_day(library_uri.station, library_uri.day_id)
-            case ORFUriType.ARCHIVE_SHOW:
-                return self._browse_show(
-                    library_uri.station, library_uri.day_id, library_uri.show_id
-                )
-            case ORFUriType.LIVE | ORFUriType.ARCHIVE_ITEM:
+            case ORFStationUri():
+                return self._browse_station(orf_uri)
+            case ORFArchiveDayUri():
+                return self._browse_day(orf_uri)
+            case ORFArchiveShowUri():
+                return self._browse_show(orf_uri)
+            case _:
                 logger.warning(
                     "ORFLibraryProvider.browse called with URI "
                     f"that does not support browsing: {uri!r}"
                 )
                 return []
 
-    def _browse_station(self, station):
-        if station not in ORFUris.stations:
+    def _browse_station(self, orf_uri: ORFStationUri) -> list[Ref]:
+        station = STATION_BY_SLUG.get(orf_uri.station)
+        if station is None:
             return []
 
-        name, loopstream_slug = ORFUris.stations[station]
         live = Ref.track(
-            uri=str(ORFLibraryUri(ORFUriType.LIVE, station)),
-            name=f"{name} Live",
+            uri=ORFLiveUri(station=station.slug).uri,
+            name=f"{station.name} Live",
         )
+        if station.loopstream_slug is None:
+            return [live]
 
         last_week = [
-            datetime.date.fromordinal(
-                datetime.datetime.now(tz=TZ).date().toordinal() - d
-            )
-            for d in range(8)
+            dt.datetime.now(tz=TZ).date() - dt.timedelta(days=d) for d in range(8)
         ]
         archive = [
             Ref.directory(
-                uri=str(
-                    ORFLibraryUri(
-                        ORFUriType.ARCHIVE_DAY, station, day.strftime("%Y%m%d")
-                    )
-                ),
-                name=day.strftime("%Y-%m-%d %A"),
+                uri=orf_uri.as_archive_day_uri(day).uri,
+                name=f"{day:%Y-%m-%d %A}",
             )
             for day in last_week
         ]
-
-        if loopstream_slug is None:
-            return [live]
         return [live, *archive]
 
-    def _get_track_title(self, item, *, afterhours=False):
+    def _get_track_title(
+        self,
+        item: dict[str, Any],
+        *,
+        afterhours: bool = False,
+    ) -> str:
         time = item["time"]
         if afterhours and self.backend.config["orfradio"]["afterhours"]:
             time = re.sub(r"^0([0-4]:)", r"O\1", time)
         return "{}: {}".format(time, item["title"])
 
-    def _browse_day(self, station, day_id):
+    def _browse_day(self, orf_uri: ORFArchiveDayUri) -> list[Ref]:
         return [
             Ref.directory(
-                uri=str(
-                    ORFLibraryUri(ORFUriType.ARCHIVE_SHOW, station, day_id, show["id"])
-                ),
+                uri=orf_uri.as_archive_show_uri(show["id"]).uri,
                 name=self._get_track_title(show, afterhours=True),
             )
-            for show in self.client.get_day(station, day_id)
+            for show in self.client.get_day(
+                station=orf_uri.station,
+                day=orf_uri.day,
+            )
         ]
 
-    def _browse_show(self, station, day_id, show_id):
+    def _browse_show(self, orf_uri: ORFArchiveShowUri) -> list[Ref]:
         return [
             Ref.track(
-                uri=str(
-                    ORFLibraryUri(
-                        ORFUriType.ARCHIVE_ITEM,
-                        station,
-                        day_id,
-                        show_id,
-                        item["id"],
-                    )
-                ),
+                uri=orf_uri.as_archive_item_uri(item["id"]).uri,
                 name=self._get_track_title(item),
             )
-            for item in self.client.get_show(station, day_id, show_id)
+            for item in self.client.get_show(
+                station=orf_uri.station,
+                day=orf_uri.day,
+                show_id=orf_uri.show_id,
+            )
         ]
 
     @override
-    def lookup(self, uri):  # noqa: PLR0911
+    def lookup(self, uri: Uri) -> list[Track]:  # noqa: PLR0911
         try:
-            library_uri = ORFLibraryUri.parse(uri)
+            orf_uri = ORFUri.parse(uri)
         except InvalidORFUriError as e:
             logger.error(e)  # noqa: TRY400
             return []
 
-        match library_uri.uri_type:
-            case ORFUriType.ROOT:
+        match orf_uri:
+            case ORFLiveUri():
+                return [Track(uri=orf_uri.uri, name="Live")]
+            case ORFStationUri():
+                return self._lookup_from_browse(self._browse_station(orf_uri))
+            case ORFArchiveDayUri():
+                return self._lookup_from_browse(self._browse_day(orf_uri))
+            case ORFArchiveShowUri():
+                return self._lookup_from_browse(self._browse_show(orf_uri))
+            case ORFArchiveItemUri():
+                return self._lookup_item(orf_uri)
+            case _:
                 logger.warning(
                     "ORFLibraryProvider.lookup called with URI "
                     f"that does not support lookup: {uri!r}"
                 )
                 return []
-            case ORFUriType.LIVE:
-                return [Track(uri=str(library_uri), name="Live")]
-            case ORFUriType.STATION:
-                return self._browse_station(library_uri.station)
-            case ORFUriType.ARCHIVE_DAY:
-                return self._browse_day(library_uri.station, library_uri.day_id)
-            case ORFUriType.ARCHIVE_SHOW:
-                return self._browse_show(
-                    library_uri.station, library_uri.day_id, library_uri.show_id
-                )
-            case ORFUriType.ARCHIVE_ITEM:
-                return self._lookup_item(
-                    library_uri.station,
-                    library_uri.day_id,
-                    library_uri.show_id,
-                    library_uri.item_id,
-                )
 
-    def _lookup_item(self, station, day_id, show_id, item_id):
-        item = self.client.get_item(station, day_id, show_id, item_id)
+    def _lookup_from_browse(self, refs: list[Ref]) -> list[Track]:
+        return [Track(uri=ref.uri, name=ref.name) for ref in refs]
+
+    def _lookup_item(self, orf_uri: ORFArchiveItemUri) -> list[Track]:
+        item = self.client.get_item(
+            station=orf_uri.station,
+            day=orf_uri.day,
+            show_id=orf_uri.show_id,
+            item_id=orf_uri.item_id,
+        )
         return [
             Track(
-                uri=str(
-                    ORFLibraryUri(
-                        ORFUriType.ARCHIVE_ITEM,
-                        station,
-                        day_id,
-                        show_id,
-                        item["id"],
-                    )
-                ),
-                artists=[Artist(name=item["artist"])],
+                uri=orf_uri.uri,
+                artists=frozenset([Artist(name=item["artist"])]),
                 length=item["length"],
                 album=Album(name=f"{item['show_long']} ({item['show_date']})"),
                 genre=item["type"],
@@ -197,79 +186,5 @@ class ORFLibraryProvider(backend.LibraryProvider):
         ]
 
     @override
-    def refresh(self, uri=None):
+    def refresh(self, uri: Uri | None = None):
         self.client.refresh()
-
-
-class ORFLibraryUri:
-    def __init__(
-        self,
-        uri_type: ORFUriType,
-        station_slug=None,
-        day_id=None,
-        show_id=None,
-        item_id=None,
-    ):
-        self.uri_type = uri_type
-        self.station = station_slug
-        self.day_id = day_id
-        self.show_id = show_id
-        self.item_id = item_id
-
-    @staticmethod
-    def parse(uri):
-        _scheme, _, path, _, _ = urllib.parse.urlsplit(uri)
-        station, live_or_day, show, item, *_ = path.split("/", 4) + 4 * [None]
-
-        if station == "":
-            return ORFLibraryUri(ORFUriType.ROOT)
-        if live_or_day is None:
-            return ORFLibraryUri(ORFUriType.STATION, station)
-        if live_or_day == "live":
-            return ORFLibraryUri(ORFUriType.LIVE, station)
-        if item:
-            return ORFLibraryUri(
-                ORFUriType.ARCHIVE_ITEM, station, live_or_day, show, item
-            )
-        if show:
-            return ORFLibraryUri(ORFUriType.ARCHIVE_SHOW, station, live_or_day, show)
-        return ORFLibraryUri(ORFUriType.ARCHIVE_DAY, station, live_or_day)
-
-        raise InvalidORFUriError(uri)
-
-    @property
-    def loopstream(self):
-        _name, loopstream_slug = ORFUris.stations[self.station]
-        return loopstream_slug
-
-    def __str__(self) -> str:
-        match self.uri_type:
-            case ORFUriType.ROOT:
-                return f"{ORFUris.ROOT}:"
-            case ORFUriType.STATION:
-                return f"{ORFUris.ROOT}:{self.station}"
-            case ORFUriType.LIVE:
-                return f"{ORFUris.ROOT}:{self.station}/live"
-            case ORFUriType.ARCHIVE_DAY:
-                return f"{ORFUris.ROOT}:{self.station}/{self.day_id}"
-            case ORFUriType.ARCHIVE_SHOW:
-                return f"{ORFUris.ROOT}:{self.station}/{self.day_id}/{self.show_id}"
-            case ORFUriType.ARCHIVE_ITEM:
-                return (
-                    f"{ORFUris.ROOT}:{self.station}/{self.day_id}"
-                    f"/{self.show_id}/{self.item_id}"
-                )
-
-
-class InvalidORFUriError(TypeError):
-    def __init__(self, uri):
-        super().__init__(f"The URI is not a valid ORFLibraryUri: {uri!r}")
-
-
-class ORFUriType(IntEnum):
-    ROOT = 0
-    STATION = 1
-    LIVE = 2
-    ARCHIVE_DAY = 3
-    ARCHIVE_SHOW = 4
-    ARCHIVE_ITEM = 5

--- a/src/mopidy_orfradio/library.py
+++ b/src/mopidy_orfradio/library.py
@@ -51,7 +51,7 @@ class ORFLibraryProvider(backend.LibraryProvider):
                 name=station.name,
             )
             for station in STATIONS
-            if station.slug in self.backend.config["orfradio"]["stations"]
+            if station.slug in self.backend.config["orfradio"]["stations"]  # type: ignore -- Fixed in mopidy >= 4.0.0a14
         ]
 
     @override
@@ -109,7 +109,7 @@ class ORFLibraryProvider(backend.LibraryProvider):
         afterhours: bool = False,
     ) -> str:
         time = item["time"]
-        if afterhours and self.backend.config["orfradio"]["afterhours"]:
+        if afterhours and self.backend.config["orfradio"]["afterhours"]:  # type: ignore -- Fixed in mopidy >= 4.0.0a14
             time = re.sub(r"^0([0-4]:)", r"O\1", time)
         return "{}: {}".format(time, item["title"])
 

--- a/src/mopidy_orfradio/playback.py
+++ b/src/mopidy_orfradio/playback.py
@@ -1,34 +1,55 @@
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING, override
 
 from mopidy import backend
 
 from mopidy_orfradio.client import ORFClient
-from mopidy_orfradio.library import InvalidORFUriError, ORFLibraryUri, ORFUriType
+from mopidy_orfradio.library import InvalidORFUriError
+from mopidy_orfradio.types import ORFArchiveItemUri, ORFLiveUri, ORFUri
+
+if TYPE_CHECKING:
+    from mopidy.audio import AudioProxy
+    from mopidy.types import Uri
+
+    from mopidy_orfradio.backend import ORFBackend
 
 logger = logging.getLogger(__name__)
 
 
 class ORFPlaybackProvider(backend.PlaybackProvider):
-    def __init__(self, audio, backend, client=None):
+    backend: ORFBackend
+    client: ORFClient
+
+    def __init__(
+        self,
+        audio: AudioProxy,
+        backend: ORFBackend,
+        client: ORFClient | None = None,
+    ):
         super().__init__(audio, backend)
         self.client = client or ORFClient(backend=self.backend)
 
-    def translate_uri(self, uri):
+    @override
+    def translate_uri(self, uri: Uri) -> Uri | None:
         try:
-            library_uri = ORFLibraryUri.parse(uri)
+            orf_uri = ORFUri.parse(uri)
         except InvalidORFUriError:
             return None
 
-        match library_uri.uri_type:
-            case ORFUriType.LIVE:
-                return self.client.get_live_url(library_uri.station)
-            case ORFUriType.ARCHIVE_ITEM:
+        match orf_uri:
+            case ORFLiveUri():
+                return self.client.get_live_url(
+                    station=orf_uri.station,
+                )
+            case ORFArchiveItemUri():
                 return self.client.get_item_url(
-                    library_uri.station,
-                    library_uri.loopstream,
-                    library_uri.day_id,
-                    library_uri.show_id,
-                    library_uri.item_id,
+                    station=orf_uri.station,
+                    day=orf_uri.day,
+                    show_id=orf_uri.show_id,
+                    item_id=orf_uri.item_id,
+                    loopstream_slug=orf_uri.loopstream_slug,
                 )
             case _:
                 return None

--- a/src/mopidy_orfradio/playback.py
+++ b/src/mopidy_orfradio/playback.py
@@ -27,7 +27,7 @@ class ORFPlaybackProvider(backend.PlaybackProvider):
         audio: AudioProxy,
         backend: ORFBackend,
         client: ORFClient | None = None,
-    ):
+    ) -> None:
         super().__init__(audio, backend)
         self.client = client or ORFClient(backend=self.backend)
 

--- a/src/mopidy_orfradio/stations.py
+++ b/src/mopidy_orfradio/stations.py
@@ -1,0 +1,19 @@
+from mopidy_orfradio.types import Station
+
+STATIONS = [
+    Station(slug="oe1", name="Ö1", loopstream_slug="oe1"),
+    Station(slug="oe3", name="Ö3", loopstream_slug="oe3"),
+    Station(slug="fm4", name="FM4", loopstream_slug="fm4"),
+    Station(slug="campus", name="Ö1 Campus", loopstream_slug=None),
+    Station(slug="bgl", name="Radio Burgenland", loopstream_slug="oe2b"),
+    Station(slug="ktn", name="Radio Kärnten", loopstream_slug="oe2k"),
+    Station(slug="noe", name="Radio Niederösterreich", loopstream_slug="oe2n"),
+    Station(slug="ooe", name="Radio Oberösterreich", loopstream_slug="oe2o"),
+    Station(slug="sbg", name="Radio Salzburg", loopstream_slug="oe2s"),
+    Station(slug="stm", name="Radio Steiermark", loopstream_slug="oe2st"),
+    Station(slug="tir", name="Radio Tirol", loopstream_slug="oe2t"),
+    Station(slug="vbg", name="Radio Vorarlberg", loopstream_slug="oe2v"),
+    Station(slug="wie", name="Radio Wien", loopstream_slug="oe2w"),
+    Station(slug="slo", name="ORF Slovenski spored", loopstream_slug=None),
+]
+STATION_BY_SLUG = {station.slug: station for station in STATIONS}

--- a/src/mopidy_orfradio/types.py
+++ b/src/mopidy_orfradio/types.py
@@ -18,7 +18,7 @@ class Station:
 
 
 class InvalidORFUriError(TypeError):
-    def __init__(self, uri: str):
+    def __init__(self, uri: str) -> None:
         super().__init__(f"The URI is not a valid ORFLibraryUri: {uri!r}")
 
 

--- a/src/mopidy_orfradio/types.py
+++ b/src/mopidy_orfradio/types.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import datetime as dt
+import urllib.parse
+from dataclasses import dataclass
+
+from mopidy.types import Uri
+
+
+@dataclass
+class Station:
+    slug: str
+    name: str
+    loopstream_slug: str | None
+
+    def as_station_uri(self) -> ORFStationUri:
+        return ORFStationUri(station=self.slug)
+
+
+class InvalidORFUriError(TypeError):
+    def __init__(self, uri: str):
+        super().__init__(f"The URI is not a valid ORFLibraryUri: {uri!r}")
+
+
+@dataclass
+class ORFUri:
+    @staticmethod
+    def parse(uri: str) -> ORFUri:
+        path = urllib.parse.urlsplit(uri).path
+        path_parts = path.split("/", 4)
+
+        match path_parts:
+            case [""]:
+                return ORFRootUri()
+            case [station]:
+                return ORFStationUri(
+                    station=station,
+                )
+            case [station, "live"]:
+                return ORFLiveUri(
+                    station=station,
+                )
+            case [station, day]:
+                return ORFArchiveDayUri(
+                    station=station,
+                    day=dt.datetime.strptime(day, "%Y%m%d").date(),  # noqa: DTZ007
+                )
+            case [station, day, show_id]:
+                return ORFArchiveShowUri(
+                    station=station,
+                    day=dt.datetime.strptime(day, "%Y%m%d").date(),  # noqa: DTZ007
+                    show_id=show_id,
+                )
+            case [station, day, show_id, item_id]:
+                return ORFArchiveItemUri(
+                    station=station,
+                    day=dt.datetime.strptime(day, "%Y%m%d").date(),  # noqa: DTZ007
+                    show_id=show_id,
+                    item_id=item_id,
+                )
+            case _:
+                raise InvalidORFUriError(uri)
+
+    @property
+    def uri(self) -> Uri:
+        return Uri(str(self))
+
+
+@dataclass
+class ORFRootUri(ORFUri):
+    def __str__(self) -> str:
+        return "orfradio:"
+
+
+@dataclass
+class ORFStationUri(ORFUri):
+    station: str
+
+    def __str__(self) -> str:
+        return f"orfradio:{self.station}"
+
+    def as_archive_day_uri(self, day: dt.date) -> ORFArchiveDayUri:
+        return ORFArchiveDayUri(
+            station=self.station,
+            day=day,
+        )
+
+
+@dataclass
+class ORFLiveUri(ORFUri):
+    station: str
+
+    def __str__(self) -> str:
+        return f"orfradio:{self.station}/live"
+
+
+@dataclass
+class ORFArchiveDayUri(ORFUri):
+    station: str
+    day: dt.date
+
+    def __str__(self) -> str:
+        return f"orfradio:{self.station}/{self.day:%Y%m%d}"
+
+    def as_archive_show_uri(self, show_id: str) -> ORFArchiveShowUri:
+        return ORFArchiveShowUri(
+            station=self.station,
+            day=self.day,
+            show_id=show_id,
+        )
+
+
+@dataclass
+class ORFArchiveShowUri(ORFUri):
+    station: str
+    day: dt.date
+    show_id: str
+
+    def __str__(self) -> str:
+        return f"orfradio:{self.station}/{self.day:%Y%m%d}/{self.show_id}"
+
+    def as_archive_item_uri(self, item_id: str) -> ORFArchiveItemUri:
+        return ORFArchiveItemUri(
+            station=self.station,
+            day=self.day,
+            show_id=self.show_id,
+            item_id=item_id,
+        )
+
+
+@dataclass
+class ORFArchiveItemUri(ORFUri):
+    station: str
+    day: dt.date
+    show_id: str
+    item_id: str
+
+    def __str__(self) -> str:
+        return (
+            f"orfradio:{self.station}/{self.day:%Y%m%d}/{self.show_id}/{self.item_id}"
+        )
+
+    @property
+    def loopstream_slug(self) -> str | None:
+        from mopidy_orfradio.stations import STATION_BY_SLUG  # noqa: PLC0415
+
+        station = STATION_BY_SLUG.get(self.station)
+        if station is None:
+            return None
+        return station.loopstream_slug

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import unittest
 from pathlib import Path
 
@@ -39,13 +40,20 @@ class ORFClientTest(unittest.TestCase):
         self.orf_client = ORFClient(self.http_client_mock)
 
     def test_get_day(self):
-        day = self.orf_client.get_day("oe1", "20170604")
+        day = self.orf_client.get_day(
+            station="oe1",
+            day=dt.date(2017, 6, 4),
+        )
         day = day[:1]  # only test against first show
 
         assert day == [{"id": "475617", "title": "Nachrichten", "time": "10:59"}]
 
     def test_get_show(self):
-        show = self.orf_client.get_show("oe1", "20170604", "475617")
+        show = self.orf_client.get_show(
+            station="oe1",
+            day=dt.date(2017, 6, 4),
+            show_id="475617",
+        )
 
         assert show == [
             {
@@ -61,7 +69,11 @@ class ORFClientTest(unittest.TestCase):
         ]
 
     def test_get_show_no_subitems(self):
-        show = self.orf_client.get_show("oe1", "20200406", "594692")
+        show = self.orf_client.get_show(
+            station="oe1",
+            day=dt.date(2020, 4, 6),
+            show_id="594692",
+        )
 
         assert show == [
             {
@@ -78,7 +90,11 @@ class ORFClientTest(unittest.TestCase):
 
     def test_get_show_zeroth_item(self):
         self.orf_client.media_types += ["S"]
-        show = self.orf_client.get_show("oe1", "20210412", "635031")
+        show = self.orf_client.get_show(
+            station="oe1",
+            day=dt.date(2021, 4, 12),
+            show_id="635031",
+        )
 
         assert show == [
             {
@@ -95,7 +111,10 @@ class ORFClientTest(unittest.TestCase):
 
     def test_get_item_broken_unicode(self):
         show = self.orf_client.get_item(
-            "fm4", "20200409", "4UP", "1586420063000-1586420268000"
+            station="fm4",
+            day=dt.date(2020, 4, 9),
+            show_id="4UP",
+            item_id="1586420063000-1586420268000",
         )
 
         assert show == {
@@ -111,7 +130,11 @@ class ORFClientTest(unittest.TestCase):
 
     def test_get_item_url_oe2(self):
         url = self.orf_client.get_item_url(
-            "wie", "oe2w", "20200615", "WXWOW", "1592222374000-1592222555000"
+            station="wie",
+            day=dt.date(2020, 6, 15),
+            show_id="WXWOW",
+            item_id="1592222374000-1592222555000",
+            loopstream_slug="oe2w",
         )
 
         assert (

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -3,59 +3,17 @@ import unittest
 from unittest.mock import Mock
 
 from mopidy.models import Ref
+from mopidy.types import Uri
 
 from mopidy_orfradio import TZ
-from mopidy_orfradio.library import ORFLibraryProvider, ORFLibraryUri, ORFUriType
-
-
-class ORFLibraryUriTest(unittest.TestCase):
-    def test_parse_root_uri(self):
-        uri = "orfradio:"
-        result = ORFLibraryUri.parse(uri)
-        assert result.uri_type == ORFUriType.ROOT
-
-    def test_parse_station_uri(self):
-        uri = "orfradio:oe1"
-        result = ORFLibraryUri.parse(uri)
-        assert result.uri_type == ORFUriType.STATION
-
-    def test_parse_live_uri(self):
-        uri = "orfradio:oe1/live"
-        result = ORFLibraryUri.parse(uri)
-        assert result.uri_type == ORFUriType.LIVE
-
-    def test_parse_day_uri(self):
-        uri = "orfradio:oe1/20140914"
-        result = ORFLibraryUri.parse(uri)
-        assert result.uri_type == ORFUriType.ARCHIVE_DAY
-        assert result.day_id == "20140914"
-
-    def test_parse_show_uri(self):
-        uri = "orfradio:oe1/20140914/382176"
-        result = ORFLibraryUri.parse(uri)
-        assert result.uri_type == ORFUriType.ARCHIVE_SHOW
-        assert result.day_id == "20140914"
-        assert result.show_id == "382176"
-
-    def test_create_root_uri(self):
-        parsed_uri = ORFLibraryUri(ORFUriType.ROOT)
-        assert str(parsed_uri) == "orfradio:"
-
-    def test_create_station_uri(self):
-        parsed_uri = ORFLibraryUri(ORFUriType.STATION, "oe1")
-        assert str(parsed_uri) == "orfradio:oe1"
-
-    def test_create_live_uri(self):
-        parsed_uri = ORFLibraryUri(ORFUriType.LIVE, "oe1")
-        assert str(parsed_uri) == "orfradio:oe1/live"
-
-    def test_create_day_uri(self):
-        parsed_uri = ORFLibraryUri(ORFUriType.ARCHIVE_DAY, "oe1", "20140914")
-        assert str(parsed_uri) == "orfradio:oe1/20140914"
-
-    def test_create_show_uri(self):
-        parsed_uri = ORFLibraryUri(ORFUriType.ARCHIVE_SHOW, "oe1", "20140914", "382176")
-        assert str(parsed_uri) == "orfradio:oe1/20140914/382176"
+from mopidy_orfradio.library import ORFLibraryProvider
+from mopidy_orfradio.types import (
+    ORFArchiveDayUri,
+    ORFArchiveShowUri,
+    ORFLiveUri,
+    ORFRootUri,
+    ORFStationUri,
+)
 
 
 class ORFLibraryProviderTest(unittest.TestCase):
@@ -87,21 +45,21 @@ class ORFLibraryProviderTest(unittest.TestCase):
 
     def test_browse_invalid_uri(self):
         uri = "foo:bar"
-        result = self.library.browse(uri)
+        result = self.library.browse(Uri(uri))
         assert result == []
 
     def test_browse_unbrowsable_uri(self):
-        uri = str(ORFLibraryUri(ORFUriType.LIVE, "oe1"))
+        uri = ORFLiveUri(station="oe1").uri
         result = self.library.browse(uri)
         assert result == []
 
     def test_browse_root(self):
-        uri = str(ORFLibraryUri(ORFUriType.ROOT))
+        uri = ORFRootUri().uri
         result = self.library.browse(uri)
         assert len(result) == 2
 
     def test_browse_station(self):
-        uri = str(ORFLibraryUri(ORFUriType.STATION, "oe1"))
+        uri = ORFStationUri(station="oe1").uri
         result = self.library.browse(uri)
         assert len(result) == 9
         assert result[0].type == Ref.TRACK
@@ -114,44 +72,63 @@ class ORFLibraryProviderTest(unittest.TestCase):
         assert result[1].name == labeltext
 
     def test_browse_archive_day(self):
-        uri = str(ORFLibraryUri(ORFUriType.ARCHIVE_DAY, "oe1", "20140914"))
+        uri = ORFArchiveDayUri(
+            station="oe1",
+            day=dt.date(2014, 9, 14),
+        ).uri
         result = self.library.browse(uri)
-        self.client_mock.get_day.assert_called_once_with("oe1", "20140914")
+        self.client_mock.get_day.assert_called_once_with(
+            station="oe1",
+            day=dt.date(2014, 9, 14),
+        )
         assert len(result) == 3
         assert result[0].type == Ref.DIRECTORY
         assert result[0].uri == "orfradio:oe1/20140914/1"
         assert result[0].name == "01:00: Item1"
 
     def test_lookup_invalid_uri(self):
-        uri = "foo:bar"
+        uri = Uri("foo:bar")
         result = self.library.lookup(uri)
         assert result == []
 
-    def test_browse_unlookable_uri(self):
-        uri = str(ORFLibraryUri(ORFUriType.ROOT))
+    def test_lookup_unlookable_uri(self):
+        uri = ORFRootUri().uri
         result = self.library.lookup(uri)
         assert result == []
 
     def test_lookup_live(self):
-        uri = str(ORFLibraryUri(ORFUriType.LIVE, "oe1"))
+        uri = ORFLiveUri(station="oe1").uri
         result = self.library.lookup(uri)
         assert len(result) == 1
         assert result[0].uri == uri
         assert result[0].name == "Live"
 
     def test_lookup_archive_day(self):
-        uri = str(ORFLibraryUri(ORFUriType.ARCHIVE_DAY, "oe1", "20140914"))
+        uri = ORFArchiveDayUri(
+            station="oe1",
+            day=dt.date(2014, 9, 14),
+        ).uri
         result = self.library.lookup(uri)
-        self.client_mock.get_day.assert_called_once_with("oe1", "20140914")
+        self.client_mock.get_day.assert_called_once_with(
+            station="oe1",
+            day=dt.date(2014, 9, 14),
+        )
         assert len(result) == 3
-        assert result[0].type == Ref.DIRECTORY
         assert result[0].uri == "orfradio:oe1/20140914/1"
         assert result[0].name == "01:00: Item1"
 
     def test_lookup_archive_show(self):
-        uri = str(ORFLibraryUri(ORFUriType.ARCHIVE_SHOW, "oe1", "20140914", "1234567"))
+        uri = ORFArchiveShowUri(
+            station="oe1",
+            day=dt.date(2014, 9, 14),
+            show_id="1234567",
+        ).uri
         result = self.library.lookup(uri)
-        self.client_mock.get_show.assert_called_once_with("oe1", "20140914", "1234567")
+        self.client_mock.get_show.assert_called_once_with(
+            station="oe1",
+            day=dt.date(2014, 9, 14),
+            show_id="1234567",
+        )
         assert len(result) == 3
         # this test might be wrong:
         assert result[0].uri == "orfradio:oe1/20140914/1234567/1"

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -1,30 +1,37 @@
+import datetime as dt
 import unittest
 from unittest.mock import Mock
 
-from mopidy_orfradio.playback import ORFLibraryUri, ORFPlaybackProvider, ORFUriType
+from mopidy.types import Uri
+
+from mopidy_orfradio.playback import ORFPlaybackProvider
+from mopidy_orfradio.types import ORFArchiveItemUri, ORFLiveUri, ORFStationUri
 
 
 class ORFLibraryUriTest(unittest.TestCase):
     def test_playback_archive_item(self):
-        library_uri = ORFLibraryUri(
-            ORFUriType.ARCHIVE_ITEM, "oe1", "20140914", "1234567"
-        )
+        library_uri = ORFArchiveItemUri(
+            station="oe1",
+            day=dt.date(2014, 9, 14),
+            show_id="1234567",
+            item_id="1633035600-1633039200",
+        ).uri
         client_mock = Mock()
         client_mock.get_item_url = Mock(return_value="result_uri")
         playback = ORFPlaybackProvider(None, None, client=client_mock)
 
-        result = playback.translate_uri(str(library_uri))
+        result = playback.translate_uri(library_uri)
 
         assert result == "result_uri"
 
     def test_playback_live(self):
-        library_uri = ORFLibraryUri(ORFUriType.LIVE, "oe1")
+        library_uri = ORFLiveUri(station="oe1").uri
 
         client_mock = Mock()
         client_mock.get_live_url = Mock(return_value="result_uri")
         playback = ORFPlaybackProvider(None, None, client=client_mock)
 
-        result = playback.translate_uri(str(library_uri))
+        result = playback.translate_uri(library_uri)
 
         assert result == "result_uri"
 
@@ -33,14 +40,14 @@ class ORFLibraryUriTest(unittest.TestCase):
         audio_mock.set_uri = Mock()
 
         playback = ORFPlaybackProvider(audio_mock, None, client=None)
-        result = playback.translate_uri("invalid")
+        result = playback.translate_uri(Uri("invalid"))
 
         assert result is None
 
     def test_playback_unplayable_url(self):
-        library_uri = ORFLibraryUri(ORFUriType.STATION, "oe1")
+        library_uri = ORFStationUri(station="oe1").uri
         playback = ORFPlaybackProvider(None, None, client=None)
 
-        result = playback.translate_uri(str(library_uri))
+        result = playback.translate_uri(library_uri)
 
         assert result is None

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,57 @@
+import datetime as dt
+
+import pytest
+
+from mopidy_orfradio.types import (
+    ORFArchiveDayUri,
+    ORFArchiveItemUri,
+    ORFArchiveShowUri,
+    ORFLiveUri,
+    ORFRootUri,
+    ORFStationUri,
+    ORFUri,
+)
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected"),
+    [
+        (
+            "orfradio:",
+            ORFRootUri(),
+        ),
+        (
+            "orfradio:oe1",
+            ORFStationUri(station="oe1"),
+        ),
+        (
+            "orfradio:oe1/live",
+            ORFLiveUri(station="oe1"),
+        ),
+        (
+            "orfradio:oe1/20140914",
+            ORFArchiveDayUri(station="oe1", day=dt.date(2014, 9, 14)),
+        ),
+        (
+            "orfradio:oe1/20140914/382176",
+            ORFArchiveShowUri(
+                station="oe1",
+                day=dt.date(2014, 9, 14),
+                show_id="382176",
+            ),
+        ),
+        (
+            "orfradio:oe1/20140914/382176/1633035600-1633039200",
+            ORFArchiveItemUri(
+                station="oe1",
+                day=dt.date(2014, 9, 14),
+                show_id="382176",
+                item_id="1633035600-1633039200",
+            ),
+        ),
+    ],
+)
+def test_orf_uri_parse(uri: str, expected: ORFUri):
+    result = ORFUri.parse(uri)
+    assert result == expected
+    assert str(result) == uri


### PR DESCRIPTION
The goal here was only to add type hints, but on the way there I ended up refactoring quite a bit to make the types more helpful in guaranteeing that the right strings parsed out of the URLs are present, depending on the URL type.

All tests pass, including type checks with pyright and ty. I'm currently listening to Xmas songs in German from ORF :christmas_tree: 

@girst Please have a look, and if you find this too invasive, or the first commit too large, I can try to redo the refactoring in smaller steps.